### PR TITLE
Fixes issue #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
-test-rules.iml
+*.iml
 target/

--- a/README.md
+++ b/README.md
@@ -19,20 +19,59 @@ A collection of useful JUnit rules from Unruly's codebases
 
 This allows you to write an acceptance/integration test before implementing a feature, and integrate it into your codebase before the implementation is complete.
 
+`@IgnoreUntil` must be present on the test method you wish to ignore. 
+
+The date/datetime value of the class level annotation can be shared across methods in the class or overridden by the method annotation.
+
 ```java
-@Rule
-IgnoreUntilRule rule = new IgnoreUntilRule();
 
-@IgnoreUntil("2014-10-30")
-@Test
-public void example_test_ignored_until_a_date() {
+@IgnoreUntil("2099-01-01")
+public class MyIgnorableTest {
 
+    @Rule public IgnoreUntilRule rule = new IgnoreUntilRule();
+
+    @IgnoreUntil
+    @Test
+    public void ignoredUntil2099-01-01() {
+    }
+
+    @IgnoreUntil
+    @Test
+    public void alsoIgnoredUntil2099-01-01() {
+    }
+
+    @IgnoreUntil("2014-10-30")
+    @Test
+    public void ignoredUntil2018-01-01() {
+    }
+
+    @IgnoreUntil("2014-10-30T17:30:00")
+    @Test
+    public void ignoredUntil2014-10-30T17:30:00() {
+    }
+
+    @Test
+    public void notIgnored() {
+    }
 }
+```
 
-@IgnoreUntil("2014-10-30T17:30:00")
-@Test
-public void example_test_ignored_until_a_datetime() {
+The class annotation is optional, you can just annotate the method.
 
+```java
+
+public class MyIgnorableTest {
+
+    @Rule public IgnoreUntilRule rule = new IgnoreUntilRule();
+
+    @IgnoreUntil("2014-10-30T17:30:00")
+    @Test
+    public void ignoredUntil2014-10-30T17:30:00() {
+    }
+
+    @Test
+    public void notIgnored() {
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,22 +32,22 @@ public class MyIgnorableTest {
 
     @IgnoreUntil
     @Test
-    public void ignoredUntil2099-01-01() {
+    public void ignoredUntil20990101() {
     }
 
     @IgnoreUntil
     @Test
-    public void alsoIgnoredUntil2099-01-01() {
+    public void alsoIgnoredUntil20990101() {
     }
 
     @IgnoreUntil("2014-10-30")
     @Test
-    public void ignoredUntil2018-01-01() {
+    public void ignoredUntil20180101() {
     }
 
     @IgnoreUntil("2014-10-30T17:30:00")
     @Test
-    public void ignoredUntil2014-10-30T17:30:00() {
+    public void ignoredUntil20141030T173000() {
     }
 
     @Test
@@ -66,7 +66,7 @@ public class MyIgnorableTest {
 
     @IgnoreUntil("2014-10-30T17:30:00")
     @Test
-    public void ignoredUntil2014-10-30T17:30:00() {
+    public void ignoredUntil20141030T173000() {
     }
 
     @Test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of useful JUnit rules from Unruly's codebases
 </dependency>
 ```
 
-## Ignore tests until a certain date.
+## Ignore tests until a certain date or datetime.
 
 This allows you to write an acceptance/integration test before implementing a feature, and integrate it into your codebase before the implementation is complete.
 
@@ -26,6 +26,12 @@ IgnoreUntilRule rule = new IgnoreUntilRule();
 @IgnoreUntil("2014-10-30")
 @Test
 public void example_test_ignored_until_a_date() {
+
+}
+
+@IgnoreUntil("2014-10-30T17:30:00")
+@Test
+public void example_test_ignored_until_a_datetime() {
 
 }
 ```

--- a/src/main/java/co/unruly/junit/IgnoreUntilRule.java
+++ b/src/main/java/co/unruly/junit/IgnoreUntilRule.java
@@ -14,7 +14,6 @@ public class IgnoreUntilRule implements TestRule {
     static final String DEFAULT_IGNORE = "2000-01-01";
     private static final Pattern DATE_REGEX =     Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
     private static final Pattern DATETIME_REGEX = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}");
-    static final String DEFAULT_IGNORE = "2000-01-01";
 
     @Override
     public Statement apply(Statement base, Description description) {

--- a/src/main/java/co/unruly/junit/IgnoreUntilRule.java
+++ b/src/main/java/co/unruly/junit/IgnoreUntilRule.java
@@ -10,12 +10,14 @@ import static org.joda.time.format.DateTimeFormat.forPattern;
 
 public class IgnoreUntilRule implements TestRule {
 
+    static final String DEFAULT_IGNORE = "2000-01-01";
+
     @Override
     public Statement apply(Statement base, Description description) {
 
         IgnoreUntil ignoreUntil = description.getAnnotation(IgnoreUntil.class);
 
-        if (ignoreUntil != null && description.getTestClass() != null) {
+        if (ignoreUntil != null && ignoreUntil.value().equals(DEFAULT_IGNORE) && description.getTestClass() != null) {
             ignoreUntil = description.getTestClass().getAnnotation(IgnoreUntil.class);
         }
 

--- a/src/main/java/co/unruly/junit/IgnoreUntilRule.java
+++ b/src/main/java/co/unruly/junit/IgnoreUntilRule.java
@@ -5,12 +5,15 @@ import org.joda.time.DateTime;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import java.util.regex.Pattern;
 
 import static org.joda.time.format.DateTimeFormat.forPattern;
 
 public class IgnoreUntilRule implements TestRule {
 
     static final String DEFAULT_IGNORE = "2000-01-01";
+    private static final Pattern DATE_REGEX =     Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+    private static final Pattern DATETIME_REGEX = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}");
 
     @Override
     public Statement apply(Statement base, Description description) {
@@ -26,11 +29,20 @@ public class IgnoreUntilRule implements TestRule {
         }
 
         String ignoreUntilDate = ignoreUntil.value();
-
-        DateTime annotationDate = forPattern("yyyy-MM-dd").parseDateTime(ignoreUntilDate);
+        DateTime annotationDate = parseDateTime(ignoreUntilDate);
 
         return annotationDate.isAfterNow() ? new AlwaysPassesStatement() : base;
 
+    }
+
+    private DateTime parseDateTime(String datetime) {
+        if (DATE_REGEX.matcher(datetime).matches()) {
+            return forPattern("yyyy-MM-dd").parseDateTime(datetime);
+        } else if (DATETIME_REGEX.matcher(datetime).matches()) {
+            return forPattern("yyyy-MM-dd'T'HH:mm:ss").parseDateTime(datetime);
+        } else {
+            throw new IllegalArgumentException("Please provide correct datetime pattern, one of: \nyyyy-MM-dd\nyyyy-MM-ddTHH:mm:ss");
+        }
     }
 
     public static class AlwaysPassesStatement extends Statement {

--- a/src/main/java/co/unruly/junit/IgnoreUntilRule.java
+++ b/src/main/java/co/unruly/junit/IgnoreUntilRule.java
@@ -14,6 +14,7 @@ public class IgnoreUntilRule implements TestRule {
     static final String DEFAULT_IGNORE = "2000-01-01";
     private static final Pattern DATE_REGEX =     Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
     private static final Pattern DATETIME_REGEX = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}");
+    static final String DEFAULT_IGNORE = "2000-01-01";
 
     @Override
     public Statement apply(Statement base, Description description) {

--- a/src/test/java/co/unruly/junit/IgnoreUntilRuleTest.java
+++ b/src/test/java/co/unruly/junit/IgnoreUntilRuleTest.java
@@ -22,6 +22,8 @@ public class IgnoreUntilRuleTest {
     @Mock Statement mockStatement;
     @Mock IgnoreUntil mockIgnoreUntilAnnotation;
     @Mock Description mockDescription;
+    private final static String DATE_PATTERN = "yyyy-MM-dd";
+    private final static String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
 
     @InjectMocks
     IgnoreUntilRule rule = new IgnoreUntilRule();
@@ -29,13 +31,40 @@ public class IgnoreUntilRuleTest {
     @Test
     public void shouldReturnOriginalStatementIfAnnotationNotPresent() {
         when(mockDescription.getAnnotation(IgnoreUntil.class)).thenReturn(null);
+        assertEquals(mockStatement, rule.apply(mockStatement, mockDescription));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfDateTimeFormatInvalid() {
+        when(mockDescription.getAnnotation(IgnoreUntil.class)).thenReturn(mockIgnoreUntilAnnotation);
+        when(mockIgnoreUntilAnnotation.value()).thenReturn("invalid");
+
+        rule.apply(mockStatement, mockDescription);
+    }
+
+    @Test
+    public void shouldReturnOriginalStatementIfIgnoreUntilDateTimeIsInThePast() {
+        String oneSecondBefore = new DateTime().minusSeconds(1).toString(DATETIME_PATTERN);
+
+        when(mockDescription.getAnnotation(IgnoreUntil.class)).thenReturn(mockIgnoreUntilAnnotation);
+        when(mockIgnoreUntilAnnotation.value()).thenReturn(oneSecondBefore);
 
         assertEquals(mockStatement, rule.apply(mockStatement, mockDescription));
     }
 
     @Test
+    public void shouldReturnAlwaysPassesStatementIfIgnoreUntilDateTimeIsInTheFuture() {
+        String oneSecondLater = new DateTime().plusSeconds(1).toString(DATETIME_PATTERN);
+
+        when(mockDescription.getAnnotation(IgnoreUntil.class)).thenReturn(mockIgnoreUntilAnnotation);
+        when(mockIgnoreUntilAnnotation.value()).thenReturn(oneSecondLater);
+
+        assertTrue(rule.apply(mockStatement, mockDescription) instanceof IgnoreUntilRule.AlwaysPassesStatement);
+    }
+
+    @Test
     public void shouldReturnOriginalStatementIfIgnoreUntilDateIsInThePast() {
-        String twoDaysAgo = new DateTime().minusDays(2).toString("yyyy-MM-dd");
+        String twoDaysAgo = new DateTime().minusDays(2).toString(DATE_PATTERN);
 
         when(mockDescription.getAnnotation(IgnoreUntil.class)).thenReturn(mockIgnoreUntilAnnotation);
         when(mockIgnoreUntilAnnotation.value()).thenReturn(twoDaysAgo);
@@ -44,8 +73,18 @@ public class IgnoreUntilRuleTest {
     }
 
     @Test
+    public void shouldReturnOriginalStatementIfIgnoreUntilDateSameAsCurrentDate() {
+        String sameDay = new DateTime().toString(DATE_PATTERN);
+
+        when(mockDescription.getAnnotation(IgnoreUntil.class)).thenReturn(mockIgnoreUntilAnnotation);
+        when(mockIgnoreUntilAnnotation.value()).thenReturn(sameDay);
+
+        assertEquals(mockStatement, rule.apply(mockStatement, mockDescription));
+    }
+
+    @Test
     public void shouldReturnAlwaysPassesStatementIfIgnoreUntilDateIsInTheFuture() {
-        String tomorrow = new DateTime().plusDays(1).toString("yyyy-MM-dd");
+        String tomorrow = new DateTime().plusDays(1).toString(DATE_PATTERN);
 
         when(mockDescription.getAnnotation(IgnoreUntil.class)).thenReturn(mockIgnoreUntilAnnotation);
         when(mockIgnoreUntilAnnotation.value()).thenReturn(tomorrow);

--- a/src/test/java/co/unruly/junit/IgnoreUntilRuleTest.java
+++ b/src/test/java/co/unruly/junit/IgnoreUntilRuleTest.java
@@ -10,6 +10,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.lang.annotation.Annotation;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -49,5 +51,55 @@ public class IgnoreUntilRuleTest {
         when(mockIgnoreUntilAnnotation.value()).thenReturn(tomorrow);
 
         assertTrue(rule.apply(mockStatement, mockDescription) instanceof IgnoreUntilRule.AlwaysPassesStatement);
+    }
+
+    @Test
+    public void shouldReturnOriginalStatementIfMethodAnnotationWithNonDefaultValueExists() throws NoSuchMethodException {
+        Annotation[] methodAnnotations = (MethodOverrideClassAnnotationTest.class).getMethod("shouldNowExecute").getDeclaredAnnotations();
+        Description testMethodDescription = Description.createTestDescription(MethodOverrideClassAnnotationTest.class, "shouldNowExecute", methodAnnotations);
+        assertEquals(2, testMethodDescription.getAnnotations().size());
+
+        assertEquals(mockStatement, rule.apply(mockStatement, testMethodDescription));
+    }
+
+    @IgnoreUntil("2099-01-01")
+    static class MethodOverrideClassAnnotationTest {
+
+        @IgnoreUntil("2018-01-01")
+        @Test
+        public void shouldNowExecute() { }
+    }
+
+    @Test
+    public void shouldReturnAlwaysPassesIfMethodAnnotationInheritsFromClassAnnotation() throws NoSuchMethodException {
+        Annotation[] methodAnnotations = (MethodInheritFromClassAnnotationTest.class).getMethod("shouldNowExecute").getDeclaredAnnotations();
+        Description testMethodDescription = Description.createTestDescription(MethodInheritFromClassAnnotationTest.class, "shouldNowExecute", methodAnnotations);
+        assertEquals(2, testMethodDescription.getAnnotations().size());
+
+        assertTrue(rule.apply(mockStatement, testMethodDescription) instanceof IgnoreUntilRule.AlwaysPassesStatement);
+    }
+
+    @IgnoreUntil("2099-01-01")
+    static class MethodInheritFromClassAnnotationTest {
+
+        @IgnoreUntil
+        @Test
+        public void shouldNowExecute() { }
+    }
+
+    @Test
+    public void shouldReturnAlwaysPassesIfOnlyMethodAnnotationExists() throws NoSuchMethodException {
+        Annotation[] methodAnnotations = (MethodAnnotationOnly.class).getMethod("shouldNowExecute").getDeclaredAnnotations();
+        Description testMethodDescription = Description.createTestDescription(MethodAnnotationOnly.class, "shouldNowExecute", methodAnnotations);
+        assertEquals(2, testMethodDescription.getAnnotations().size());
+
+        assertTrue(rule.apply(mockStatement, testMethodDescription) instanceof IgnoreUntilRule.AlwaysPassesStatement);
+    }
+
+    static class MethodAnnotationOnly {
+
+        @IgnoreUntil("2099-01-01")
+        @Test
+        public void shouldNowExecute() { }
     }
 }


### PR DESCRIPTION
`@IgnoreUntil` annotation can now be on a method only.
`@IgnoreUntil` method annotation overrides class annotation when non-default value set.